### PR TITLE
test files published in release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test
+scripts


### PR DESCRIPTION
Hi @runk 

It'd be nice if the test assets weren't published to npm to save everybody a little bit of bandwidth.

As an aside, I noticed because I was using jszip to compress a node project which gets deployed to Amazon Lambda (in a zip file).  The problem is jszip isn't compressing `test/data/collation.zip` correctly and stores only part of the file with a bad CRC.  That's not your problem of course, but I thought I'd mention it.