### PR TITLE
Use Buffer.allocUnsafe instead of deprecated Buffer API

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports.detectFile = function(filepath, opts, cb) {
 
   if (opts && opts.sampleSize) {
     fd = fs.openSync(filepath, 'r'),
-      sample = new Buffer(opts.sampleSize);
+      sample = Buffer.allocUnsafe(opts.sampleSize);
 
     fs.read(fd, sample, 0, opts.sampleSize, null, function(err) {
       handler(err, sample);
@@ -111,7 +111,7 @@ module.exports.detectFile = function(filepath, opts, cb) {
 module.exports.detectFileSync = function(filepath, opts) {
   if (opts && opts.sampleSize) {
     var fd = fs.openSync(filepath, 'r'),
-      sample = new Buffer(opts.sampleSize);
+      sample = Buffer.allocUnsafe(opts.sampleSize);
 
     fs.readSync(fd, sample, 0, opts.sampleSize);
     fs.closeSync(fd);


### PR DESCRIPTION
The Buffer constructor is deprecated as of Node v6.0.0 due to security concerns.

Ref: nodejs/node#19079
Ref: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor
Ref: https://nodejs.org/api/buffer.html#buffer_class_buffer