### PR TITLE
Compatilibilty for web and react-native

### DIFF
--- a/encoding/iso2022.js
+++ b/encoding/iso2022.js
@@ -1,4 +1,4 @@
-var util = require('util'),
+var util = require('../util'),
   Match = require ('../match');
 
 

--- a/encoding/mbcs.js
+++ b/encoding/mbcs.js
@@ -1,4 +1,4 @@
-var util = require('util'),
+var util = require('../util'),
   Match = require ('../match');
 
 /**

--- a/encoding/sbcs.js
+++ b/encoding/sbcs.js
@@ -1,4 +1,4 @@
-var util = require('util'),
+var util = require('../util'),
   Match = require ('../match');
 
 /**

--- a/encoding/unicode.js
+++ b/encoding/unicode.js
@@ -1,5 +1,5 @@
 'use strict';
-var util = require('util'),
+var util = require('../util'),
   Match = require ('../match');
 
 /**

--- a/fs.js
+++ b/fs.js
@@ -1,0 +1,46 @@
+var fs = require('fs');
+var self = require('./index');
+
+module.exports.detectFile = function(filepath, opts, cb) {
+    if (typeof opts === 'function') {
+      cb = opts;
+      opts = undefined;
+    }
+  
+    var fd;
+  
+    var handler = function(err, buffer) {
+      if (fd) {
+        fs.closeSync(fd);
+      }
+  
+      if (err) return cb(err, null);
+      cb(null, self.detect(buffer, opts));
+    };
+  
+    if (opts && opts.sampleSize) {
+      fd = fs.openSync(filepath, 'r'),
+        sample = Buffer.allocUnsafe(opts.sampleSize);
+  
+      fs.read(fd, sample, 0, opts.sampleSize, null, function(err) {
+        handler(err, sample);
+      });
+      return;
+    }
+  
+    fs.readFile(filepath, handler);
+  };
+  
+  module.exports.detectFileSync = function(filepath, opts) {
+    if (opts && opts.sampleSize) {
+      var fd = fs.openSync(filepath, 'r'),
+        sample = Buffer.allocUnsafe(opts.sampleSize);
+  
+      fs.readSync(fd, sample, 0, opts.sampleSize);
+      fs.closeSync(fd);
+      return self.detect(sample, opts);
+    }
+  
+    return self.detect(fs.readFileSync(filepath), opts);
+  };
+  

--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-
-var fs = require('fs');
-
 var utf8  = require('./encoding/utf8'),
   unicode = require('./encoding/unicode'),
   mbcs    = require('./encoding/mbcs'),
@@ -76,49 +73,6 @@ module.exports.detect = function(buffer, opts) {
   else {
     return matches.length > 0 ? matches[0].name : null;
   }
-};
-
-module.exports.detectFile = function(filepath, opts, cb) {
-  if (typeof opts === 'function') {
-    cb = opts;
-    opts = undefined;
-  }
-
-  var fd;
-
-  var handler = function(err, buffer) {
-    if (fd) {
-      fs.closeSync(fd);
-    }
-
-    if (err) return cb(err, null);
-    cb(null, self.detect(buffer, opts));
-  };
-
-  if (opts && opts.sampleSize) {
-    fd = fs.openSync(filepath, 'r'),
-      sample = Buffer.allocUnsafe(opts.sampleSize);
-
-    fs.read(fd, sample, 0, opts.sampleSize, null, function(err) {
-      handler(err, sample);
-    });
-    return;
-  }
-
-  fs.readFile(filepath, handler);
-};
-
-module.exports.detectFileSync = function(filepath, opts) {
-  if (opts && opts.sampleSize) {
-    var fd = fs.openSync(filepath, 'r'),
-      sample = Buffer.allocUnsafe(opts.sampleSize);
-
-    fs.readSync(fd, sample, 0, opts.sampleSize);
-    fs.closeSync(fd);
-    return self.detect(sample, opts);
-  }
-
-  return self.detect(fs.readFileSync(filepath), opts);
 };
 
 // Wrappers for the previous functions to return all encodings

--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,9 +2075,9 @@
       "dev": true
     },
     "npm": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.10.1.tgz",
-      "integrity": "sha512-ejR83c5aPTip5hPhziypqkJu06vb5tDIugCXx1c5+04RbMjtZeMA6BfsuGnV9EBdEwzKoaHkQ9sJWQAq+LjHYw==",
+      "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.4.tgz",
+      "integrity": "sha512-vTcUL4SCg3AzwInWTbqg1OIaOXlzKSS8Mb8kc5avwrJpcvevDA5J9BhYSuei+fNs3pwOp4lzA5x2FVDXACvoXA==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -2086,16 +2086,16 @@
         "ansistyles": "~0.1.3",
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.2",
+        "bin-links": "^1.1.6",
         "bluebird": "^3.5.5",
         "byte-size": "^5.0.1",
-        "cacache": "^11.3.3",
+        "cacache": "^12.0.3",
         "call-limit": "^1.1.1",
-        "chownr": "^1.1.2",
+        "chownr": "^1.1.3",
         "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.5.1",
-        "cmd-shim": "~2.0.2",
+        "cmd-shim": "^3.0.3",
         "columnify": "~1.5.4",
         "config-chain": "^1.1.12",
         "debuglog": "*",
@@ -2107,13 +2107,14 @@
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
+        "gentle-fs": "^2.3.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
+        "graceful-fs": "^4.2.3",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.7.1",
+        "hosted-git-info": "^2.8.5",
         "iferr": "^1.0.2",
         "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
         "inflight": "~1.0.6",
         "inherits": "^2.0.4",
         "ini": "^1.3.5",
@@ -2121,13 +2122,13 @@
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.0",
-        "libnpm": "^3.0.0",
-        "libnpmaccess": "*",
-        "libnpmhook": "^5.0.2",
-        "libnpmorg": "*",
-        "libnpmsearch": "^2.0.1",
-        "libnpmteam": "*",
+        "libcipm": "^4.0.7",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
         "libnpx": "^10.2.0",
         "lock-verify": "^2.1.0",
         "lockfile": "^1.0.4",
@@ -2147,33 +2148,33 @@
         "mississippi": "^3.0.0",
         "mkdirp": "~0.5.1",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^5.0.2",
+        "node-gyp": "^5.0.5",
         "nopt": "~4.0.1",
         "normalize-package-data": "^2.5.0",
         "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^3.0.0",
-        "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.4.4",
-        "npm-pick-manifest": "^2.2.3",
-        "npm-profile": "*",
-        "npm-registry-fetch": "^3.9.1",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.4",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.7",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.2",
+        "npm-registry-fetch": "^4.0.2",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.5.1",
+        "pacote": "^9.5.11",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.8.1",
+        "query-string": "^6.8.2",
         "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
+        "read-cmd-shim": "^1.0.5",
         "read-installed": "~4.0.3",
-        "read-package-json": "^2.0.13",
+        "read-package-json": "^2.1.1",
         "read-package-tree": "^5.3.1",
         "readable-stream": "^3.4.0",
         "readdir-scoped-modules": "^1.1.0",
@@ -2181,14 +2182,14 @@
         "retry": "^0.12.0",
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.7.0",
+        "semver": "^5.7.1",
         "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
         "ssri": "^6.0.1",
-        "stringify-package": "^1.0.0",
-        "tar": "^4.4.10",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
@@ -2196,7 +2197,7 @@
         "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
-        "uuid": "^3.3.2",
+        "uuid": "^3.3.3",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
@@ -2219,7 +2220,7 @@
           "dev": true
         },
         "agent-base": {
-          "version": "4.2.1",
+          "version": "4.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -2227,7 +2228,7 @@
           }
         },
         "agentkeepalive": {
-          "version": "3.4.1",
+          "version": "3.5.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -2367,14 +2368,15 @@
           }
         },
         "bin-links": {
-          "version": "1.1.2",
+          "version": "1.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
+            "bluebird": "^3.5.3",
+            "cmd-shim": "^3.0.0",
+            "gentle-fs": "^2.3.0",
+            "graceful-fs": "^4.1.15",
+            "npm-normalize-package-bin": "^1.0.0",
             "write-file-atomic": "^2.3.0"
           }
         },
@@ -2427,7 +2429,7 @@
           "dev": true
         },
         "cacache": {
-          "version": "11.3.3",
+          "version": "12.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -2436,6 +2438,7 @@
             "figgy-pudding": "^3.5.1",
             "glob": "^7.1.4",
             "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
             "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
@@ -2445,21 +2448,6 @@
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "call-limit": {
@@ -2493,7 +2481,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true
         },
@@ -2565,7 +2553,7 @@
           "dev": true
         },
         "cmd-shim": {
-          "version": "2.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -2973,7 +2961,7 @@
           }
         },
         "es6-promise": {
-          "version": "4.2.6",
+          "version": "4.2.8",
           "bundled": true,
           "dev": true
         },
@@ -3131,11 +3119,22 @@
           }
         },
         "fs-minipass": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
           }
         },
         "fs-vacuum": {
@@ -3236,14 +3235,17 @@
           "dev": true
         },
         "gentle-fs": {
-          "version": "2.0.1",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.1.2",
+            "chownr": "^1.1.2",
+            "cmd-shim": "^3.0.3",
             "fs-vacuum": "^1.2.10",
             "graceful-fs": "^4.1.11",
             "iferr": "^0.1.5",
+            "infer-owner": "^1.0.4",
             "mkdirp": "^0.5.1",
             "path-is-inside": "^1.0.2",
             "read-cmd-shim": "^1.0.1",
@@ -3330,7 +3332,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.0",
+          "version": "4.2.3",
           "bundled": true,
           "dev": true
         },
@@ -3372,7 +3374,7 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.7.1",
+          "version": "2.8.5",
           "bundled": true,
           "dev": true
         },
@@ -3401,11 +3403,11 @@
           }
         },
         "https-proxy-agent": {
-          "version": "2.2.1",
+          "version": "2.2.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "^4.1.0",
+            "agent-base": "^4.3.0",
             "debug": "^3.1.0"
           }
         },
@@ -3431,7 +3433,7 @@
           "dev": true
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -3445,6 +3447,11 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "infer-owner": {
+          "version": "1.0.4",
           "bundled": true,
           "dev": true
         },
@@ -3680,7 +3687,7 @@
           }
         },
         "libcipm": {
-          "version": "4.0.0",
+          "version": "4.0.7",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -3702,48 +3709,41 @@
           }
         },
         "libnpm": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.3",
             "find-npm-prefix": "^1.0.2",
-            "libnpmaccess": "^3.0.1",
+            "libnpmaccess": "^3.0.2",
             "libnpmconfig": "^1.2.1",
-            "libnpmhook": "^5.0.2",
-            "libnpmorg": "^1.0.0",
-            "libnpmpublish": "^1.1.0",
-            "libnpmsearch": "^2.0.0",
-            "libnpmteam": "^1.0.1",
+            "libnpmhook": "^5.0.3",
+            "libnpmorg": "^1.0.1",
+            "libnpmpublish": "^1.1.2",
+            "libnpmsearch": "^2.0.2",
+            "libnpmteam": "^1.0.2",
             "lock-verify": "^2.0.2",
             "npm-lifecycle": "^3.0.0",
             "npm-logical-tree": "^1.2.1",
             "npm-package-arg": "^6.1.0",
-            "npm-profile": "^4.0.1",
-            "npm-registry-fetch": "^3.8.0",
+            "npm-profile": "^4.0.2",
+            "npm-registry-fetch": "^4.0.0",
             "npmlog": "^4.1.2",
-            "pacote": "^9.2.3",
+            "pacote": "^9.5.3",
             "read-package-json": "^2.0.13",
             "stringify-package": "^1.0.0"
           }
         },
         "libnpmaccess": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "get-stream": "^4.0.0",
             "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^3.8.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmconfig": {
@@ -3797,36 +3797,29 @@
           }
         },
         "libnpmhook": {
-          "version": "5.0.2",
+          "version": "5.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmorg": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmpublish": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -3836,37 +3829,30 @@
             "lodash.clonedeep": "^4.5.0",
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
-            "npm-registry-fetch": "^3.8.0",
+            "npm-registry-fetch": "^4.0.0",
             "semver": "^5.5.1",
             "ssri": "^6.0.1"
           }
         },
         "libnpmsearch": {
-          "version": "2.0.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpmteam": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
             "get-stream": "^4.0.0",
-            "npm-registry-fetch": "^3.8.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "libnpx": {
@@ -4004,15 +3990,15 @@
           }
         },
         "make-fetch-happen": {
-          "version": "4.0.2",
+          "version": "5.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
-            "cacache": "^11.3.3",
+            "cacache": "^12.0.0",
             "http-cache-semantics": "^3.8.1",
             "http-proxy-agent": "^2.1.0",
-            "https-proxy-agent": "^2.2.1",
+            "https-proxy-agent": "^2.2.3",
             "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "node-fetch-npm": "^2.0.2",
@@ -4065,28 +4051,23 @@
           "bundled": true,
           "dev": true
         },
-        "minipass": {
-          "version": "2.3.3",
+        "minizlib": {
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "minipass": "^2.9.0"
           },
           "dependencies": {
-            "yallist": {
-              "version": "3.0.2",
+            "minipass": {
+              "version": "2.9.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
             }
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minipass": "^2.2.1"
           }
         },
         "mississippi": {
@@ -4155,7 +4136,7 @@
           }
         },
         "node-gyp": {
-          "version": "5.0.2",
+          "version": "5.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4168,7 +4149,7 @@
             "request": "^2.87.0",
             "rimraf": "2",
             "semver": "~5.3.0",
-            "tar": "^4.4.8",
+            "tar": "^4.4.12",
             "which": "1"
           },
           "dependencies": {
@@ -4227,9 +4208,12 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
         },
         "npm-cache-filename": {
           "version": "1.0.2",
@@ -4237,7 +4221,7 @@
           "dev": true
         },
         "npm-install-checks": {
-          "version": "3.0.0",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4245,7 +4229,7 @@
           }
         },
         "npm-lifecycle": {
-          "version": "3.0.0",
+          "version": "3.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4264,19 +4248,24 @@
           "bundled": true,
           "dev": true
         },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
         "npm-package-arg": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
+            "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
-            "semver": "^5.5.0",
+            "semver": "^5.6.0",
             "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
-          "version": "1.4.4",
+          "version": "1.4.7",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4285,7 +4274,7 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "2.2.3",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4295,17 +4284,17 @@
           }
         },
         "npm-profile": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
             "figgy-pudding": "^3.4.1",
-            "npm-registry-fetch": "^3.8.0"
+            "npm-registry-fetch": "^4.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "3.9.1",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4313,27 +4302,15 @@
             "bluebird": "^3.5.1",
             "figgy-pudding": "^3.4.1",
             "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^4.0.2",
-            "npm-package-arg": "^6.1.0"
+            "make-fetch-happen": "^5.0.0",
+            "npm-package-arg": "^6.1.0",
+            "safe-buffer": "^5.2.0"
           },
           "dependencies": {
-            "make-fetch-happen": {
-              "version": "4.0.2",
+            "safe-buffer": {
+              "version": "5.2.0",
               "bundled": true,
-              "dev": true,
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^11.3.3",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1",
-                "lru-cache": "^5.1.1",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^4.0.0",
-                "ssri": "^6.0.0"
-              }
+              "dev": true
             }
           }
         },
@@ -4470,26 +4447,29 @@
           }
         },
         "pacote": {
-          "version": "9.5.1",
+          "version": "9.5.11",
           "bundled": true,
           "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
-            "cacache": "^11.3.2",
+            "cacache": "^12.0.2",
+            "chownr": "^1.1.2",
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.1.0",
             "glob": "^7.1.3",
+            "infer-owner": "^1.0.4",
             "lru-cache": "^5.1.1",
-            "make-fetch-happen": "^4.0.1",
+            "make-fetch-happen": "^5.0.0",
             "minimatch": "^3.0.4",
             "minipass": "^2.3.5",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "normalize-package-data": "^2.4.0",
+            "npm-normalize-package-bin": "^1.0.0",
             "npm-package-arg": "^6.1.0",
             "npm-packlist": "^1.1.12",
-            "npm-pick-manifest": "^2.2.3",
-            "npm-registry-fetch": "^3.8.0",
+            "npm-pick-manifest": "^3.0.0",
+            "npm-registry-fetch": "^4.0.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^1.1.1",
@@ -4498,13 +4478,13 @@
             "safe-buffer": "^5.1.2",
             "semver": "^5.6.0",
             "ssri": "^6.0.1",
-            "tar": "^4.4.8",
+            "tar": "^4.4.10",
             "unique-filename": "^1.1.1",
             "which": "^1.3.1"
           },
           "dependencies": {
             "minipass": {
-              "version": "2.3.5",
+              "version": "2.9.0",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -4696,7 +4676,7 @@
           "dev": true
         },
         "query-string": {
-          "version": "6.8.1",
+          "version": "6.8.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4737,7 +4717,7 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.1",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4759,7 +4739,7 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.13",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4767,7 +4747,7 @@
             "graceful-fs": "^4.1.2",
             "json-parse-better-errors": "^1.0.1",
             "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
+            "npm-normalize-package-bin": "^1.0.0"
           }
         },
         "read-package-tree": {
@@ -4899,7 +4879,7 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true
         },
@@ -4942,37 +4922,42 @@
           "bundled": true,
           "dev": true
         },
-        "slash": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "slide": {
           "version": "1.1.6",
           "bundled": true,
           "dev": true
         },
         "smart-buffer": {
-          "version": "4.0.1",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true
         },
         "socks": {
-          "version": "2.2.0",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.0.1"
+            "ip": "1.1.5",
+            "smart-buffer": "^4.1.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "~4.2.0",
-            "socks": "~2.2.0"
+            "agent-base": "~4.2.1",
+            "socks": "~2.3.2"
+          },
+          "dependencies": {
+            "agent-base": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "es6-promisify": "^5.0.0"
+              }
+            }
           }
         },
         "sorted-object": {
@@ -5168,7 +5153,7 @@
           }
         },
         "stringify-package": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true,
           "dev": true
         },
@@ -5199,13 +5184,13 @@
           }
         },
         "tar": {
-          "version": "4.4.10",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.5",
+            "minipass": "^2.8.6",
             "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
@@ -5213,18 +5198,13 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "2.3.5",
+              "version": "2.9.0",
               "bundled": true,
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
               }
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true,
-              "dev": true
             }
           }
         },
@@ -5405,7 +5385,7 @@
           }
         },
         "uuid": {
-          "version": "3.3.2",
+          "version": "3.3.3",
           "bundled": true,
           "dev": true
         },

--- a/util.js
+++ b/util.js
@@ -1,0 +1,5 @@
+module.exports.inherits = function(a, b) {
+    for (var key of Object.keys(b.prototype)) {
+        a.prototype[key] = b.prototype[key];
+    }
+}


### PR DESCRIPTION
This module can't be used in browser or react-native since the modules `fs` and `util` are not available.

- Implemented own `util.inherits` function
- Moved functions which need the `fs` module to separate file `fs.js`

References #24