### PR TITLE
make type definitions compatible with browser

### DIFF
--- a/src/encoding/index.ts
+++ b/src/encoding/index.ts
@@ -9,8 +9,8 @@ export interface Recogniser {
 export interface Context {
   fByteStats: number[];
   fC1Bytes: boolean;
-  fRawInput: Buffer;
+  fRawInput: Uint8Array;
   fRawLength: number;
-  fInputBytes: Buffer;
+  fInputBytes: Uint8Array;
   fInputLen: number;
 }

--- a/src/encoding/unicode.ts
+++ b/src/encoding/unicode.ts
@@ -52,7 +52,7 @@ export class UTF_16LE implements Recogniser {
 }
 
 interface WithGetChar {
-  getChar(input: Buffer, index: number): number;
+  getChar(input: Uint8Array, index: number): number;
 }
 
 class UTF_32 implements Recogniser, WithGetChar {
@@ -60,7 +60,7 @@ class UTF_32 implements Recogniser, WithGetChar {
     return 'UTF-32';
   }
 
-  getChar(input: Buffer, index: number): number {
+  getChar(input: Uint8Array, index: number): number {
     return -1;
   }
 
@@ -114,7 +114,7 @@ export class UTF_32BE extends UTF_32 {
   name() {
     return 'UTF-32BE';
   }
-  getChar(input: Buffer, index: number) {
+  getChar(input: Uint8Array, index: number) {
     return (
       ((input[index + 0] & 0xff) << 24) |
       ((input[index + 1] & 0xff) << 16) |
@@ -129,7 +129,7 @@ export class UTF_32LE extends UTF_32 {
     return 'UTF-32LE';
   }
 
-  getChar(input: Buffer, index: number) {
+  getChar(input: Uint8Array, index: number) {
     return (
       ((input[index + 3] & 0xff) << 24) |
       ((input[index + 2] & 0xff) << 16) |

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,12 +50,12 @@ const recognisers: Recogniser[] = [
 
 type DetectResult = Match[] | string | null;
 
-export const detect = (buffer: Buffer): string | null => {
+export const detect = (buffer: Uint8Array): string | null => {
   const matches: Match[] = analyse(buffer);
   return matches.length > 0 ? matches[0].name : null;
 };
 
-export const analyse = (buffer: Buffer): Match[] => {
+export const analyse = (buffer: Uint8Array): Match[] => {
   // Tally up the byte occurrence statistics.
   const fByteStats = [];
   for (let i = 0; i < 256; i++) fByteStats[i] = 0;


### PR DESCRIPTION
Hello @runk!

Great job on the library.

I've noticed that you mention browser compatibility in your `1.0.0`, however your types aren't browser-compatible. Since there is no `Buffer` type in browser I've changed it to `Uint8Array`. It doesn't change anything from NodeJS perspective, because `Buffer` inherits `Uint8Array`.