### PR TITLE
fix: change Shift-JIS MIME to Shift_JIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ chardet
 - ISO-2022-JP
 - ISO-2022-KR
 - ISO-2022-CN
-- Shift-JIS
+- Shift_JIS
 - Big5
 - EUC-JP
 - EUC-KR

--- a/src/encoding/mbcs.test.ts
+++ b/src/encoding/mbcs.test.ts
@@ -3,8 +3,8 @@ import * as chardet from '..';
 describe('Multibyte Character Sets', () => {
   var base = __dirname + '/../test/data/encodings';
 
-  it('should return SHIFT-JIS', () => {
-    expect(chardet.detectFileSync(base + '/shiftjis')).toBe('Shift-JIS');
+  it('should return Shift_JIS', () => {
+    expect(chardet.detectFileSync(base + '/shiftjis')).toBe('Shift_JIS');
   });
 
   it('should return GB18030', () => {

--- a/src/encoding/mbcs.ts
+++ b/src/encoding/mbcs.ts
@@ -201,11 +201,11 @@ class mbcs implements Recogniser {
 }
 
 /**
- * Shift-JIS charset recognizer.
+ * Shift_JIS charset recognizer.
  */
 export class sjis extends mbcs {
   name() {
-    return 'Shift-JIS';
+    return 'Shift_JIS';
   }
   language() {
     return 'ja';


### PR DESCRIPTION
Hi @runk! great library code! ✋ 

So, I'm writing some unit tests with your library and [detect-character-encoding](https://www.npmjs.com/package/detect-character-encoding) to compare results, because I'm trying to remove this from one project dependencies and starting use yours. Anyway, I've discovered a critical typo with the `Shift-JIS` MIME, which must be `Shift_JIS`. 

You can check the name here: https://www.iana.org/assignments/character-sets/character-sets.xhtml
Also here: https://en.wikipedia.org/wiki/Shift_JIS
And finally, but not least: https://github.com/sonicdoe/detect-character-encoding/blob/66918908e7a792083789eb26dbe26d4fd107bc52/vendor/icu/i18n/csrmbcs.cpp#L280