### PR TITLE
BREAKING CHANGE: add strict input check allowing only byte arrays as …

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "maxLineLength": 80
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,14 @@ import * as unicode from './encoding/unicode';
 import * as mbcs from './encoding/mbcs';
 import * as sbcs from './encoding/sbcs';
 import * as iso2022 from './encoding/iso2022';
+import { isByteArray } from './utils';
 
 interface FullOptions {
-  sampleSize: number,
-  offset: number
+  sampleSize: number;
+  offset: number;
 }
 
-export type Options = Partial<FullOptions>
+export type Options = Partial<FullOptions>;
 
 const recognisers: Recogniser[] = [
   new Utf8(),
@@ -53,6 +54,10 @@ export const detect = (buffer: Uint8Array): string | null => {
 };
 
 export const analyse = (buffer: Uint8Array): AnalyseResult => {
+  if (!isByteArray(buffer)) {
+    throw new Error('Input must be a byte array, e.g. Buffer or Uint8Array');
+  }
+
   // Tally up the byte occurrence statistics.
   const byteStats = [];
   for (let i = 0; i < 256; i++) byteStats[i] = 0;
@@ -88,9 +93,12 @@ export const analyse = (buffer: Uint8Array): AnalyseResult => {
     });
 
   return matches as Match[];
-}
+};
 
-export const detectFile = (filepath: string, opts: Options = {}): Promise<DetectResult> =>
+export const detectFile = (
+  filepath: string,
+  opts: Options = {}
+): Promise<DetectResult> =>
   new Promise((resolve, reject) => {
     let fd: any;
     const fs = loadFs();
@@ -120,7 +128,10 @@ export const detectFile = (filepath: string, opts: Options = {}): Promise<Detect
     fs.readFile(filepath, handler);
   });
 
-export const detectFileSync = (filepath: string, opts: Options = {}): DetectResult => {
+export const detectFileSync = (
+  filepath: string,
+  opts: Options = {}
+): DetectResult => {
   const fs = loadFs();
 
   if (opts && opts.sampleSize) {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,18 @@
+import { isByteArray } from './utils';
+
+describe('isByteArray', () => {
+  test('positives', () => {
+    expect(isByteArray(Buffer.from('hello'))).toBe(true);
+    expect(isByteArray(new Uint8Array(0))).toBe(true);
+    expect(isByteArray(new Uint8Array(1))).toBe(true);
+    expect(isByteArray([])).toBe(true);
+    expect(isByteArray([1])).toBe(true);
+  });
+
+  test('negatives', () => {
+    expect(isByteArray(null)).toBe(false);
+    expect(isByteArray('')).toBe(false);
+    expect(isByteArray('hello')).toBe(false);
+    expect(isByteArray(123)).toBe(false);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,7 @@
+// May also check if every element is a number <= 255 but
+// it a little bit slower
+export const isByteArray = (input: any): input is Uint8Array => {
+  if (input == null || typeof input != 'object') return false;
+
+  return isFinite(input.length) && input.length >= 0;
+};


### PR DESCRIPTION
…inputs

From this release, only instances of Array with numeric values <= 255 are accepted as inputs. No strings or anything else except shapes like `Buffer` or `Uint8Array`.