### PR TITLE
feat: add strict input check allowing only byte arrays as inputs (#87)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,10 @@ export const detect = (buffer: Uint8Array): string | null => {
 };
 
 export const analyse = (buffer: Uint8Array): AnalyseResult => {
+  if (!isByteArray(buffer)) {
+    throw new Error('Input must be a byte array, e.g. Buffer or Uint8Array');
+  }
+
   // Tally up the byte occurrence statistics.
   const byteStats = [];
   for (let i = 0; i < 256; i++) byteStats[i] = 0;


### PR DESCRIPTION
BREAKING CHANGE: From this release, only instances of Array with numeric values <= 255 are accepted as inputs. No strings or anything else except shapes like `Buffer` or `Uint8Array`.